### PR TITLE
fix(u-read-more): 修复 init 方法无法在外部调用的问题

### DIFF
--- a/src/uni_modules/uview-pro/components/u-read-more/u-read-more.vue
+++ b/src/uni_modules/uview-pro/components/u-read-more/u-read-more.vue
@@ -119,6 +119,10 @@ function init() {
         }
     });
 }
+// 显式暴露init方法
+defineExpose({
+    init
+});
 
 /**
  * 展开或者收起内容


### PR DESCRIPTION
在 Vue 3 的 <script setup> 中，函数默认是私有的，需通过 defineExpose 显式暴露。 u-read-more.vue 中的 init 方法未暴露，导致外部无法调用。