### PR TITLE
fix(u-line-progress): type 属性设置后仍被 active-color 内联样式覆盖

### DIFF
--- a/src/uni_modules/uview-pro/components/u-line-progress/u-line-progress.vue
+++ b/src/uni_modules/uview-pro/components/u-line-progress/u-line-progress.vue
@@ -65,7 +65,7 @@ const slots = useSlots();
 const progressStyle = computed(() => {
     let style: Record<string, string> = {};
     style.width = props.percent + '%';
-    if (props.activeColor) style.backgroundColor = props.activeColor;
+    if (!props.type && props.activeColor) style.backgroundColor = props.activeColor;
     return style;
 });
 </script>


### PR DESCRIPTION
组件计算 progressStyle 时未判断 type 是否存在，  
导致 active-color 始终写入内联样式，覆盖 type 主题类样式。  
现增加判断：仅当未设置 type 时才使用 active-color。

修复后行为与文档“type 设置时 active-color 失效”保持一致。