### PR TITLE
修复uniapp发行小程序时require报错问题

### DIFF
--- a/src/uni_modules/uview-pro/components/u-calendar/types.ts
+++ b/src/uni_modules/uview-pro/components/u-calendar/types.ts
@@ -1,6 +1,7 @@
 import { type ExtractPropTypes, type PropType } from 'vue';
 import type { CalendarChangeDate, CalendarChangeRange, CalendarMode, ThemeType } from '../../types/global';
-import { baseProps } from '../common/props';
+import * as props from '../common/props';
+const { baseProps } = props;
 
 /**
  * calendar 日历类型定义

--- a/src/uni_modules/uview-pro/components/u-collapse-item/types.ts
+++ b/src/uni_modules/uview-pro/components/u-collapse-item/types.ts
@@ -1,6 +1,7 @@
 import type { ExtractPropTypes, PropType } from 'vue';
 import type { TextAlign } from '../../types/global';
-import { baseProps } from '../common/props';
+import * as props from '../common/props';
+const { baseProps } = props;
 
 /**
  * u-collapse-item 手风琴Item Props

--- a/src/uni_modules/uview-pro/components/u-collapse/types.ts
+++ b/src/uni_modules/uview-pro/components/u-collapse/types.ts
@@ -1,5 +1,6 @@
 import type { ExtractPropTypes, PropType } from 'vue';
-import { baseProps } from '../common/props';
+import * as props from '../common/props';
+const { baseProps } = props;
 
 /**
  * u-collapse 手风琴 Props

--- a/src/uni_modules/uview-pro/components/u-icon/types.ts
+++ b/src/uni_modules/uview-pro/components/u-icon/types.ts
@@ -1,6 +1,7 @@
 import type { ExtractPropTypes, PropType } from 'vue';
 import type { IconLabelPosition, ImgMode } from '../../types/global';
-import { baseProps } from '../common/props';
+import * as props from '../common/props';
+const { baseProps } = props;
 
 /**
  * u-icon 组件 Props 类型定义

--- a/src/uni_modules/uview-pro/components/u-text/types.ts
+++ b/src/uni_modules/uview-pro/components/u-text/types.ts
@@ -1,6 +1,7 @@
 import type { ExtractPropTypes, PropType } from 'vue';
 import type { ThemeType } from '../../types/global';
-import { baseProps } from '../common/props';
+import * as props from '../common/props';
+const { baseProps } = props;
 
 export const TextProps = {
     ...baseProps,


### PR DESCRIPTION
修复uniapp发行小程序时，报错require("../common/props.js")报错问题 