### PR TITLE
fix(types): 修正组件声明文件中uLoadmore的命名大小写问题

### DIFF
--- a/src/uni_modules/uview-pro/types/components.d.ts
+++ b/src/uni_modules/uview-pro/types/components.d.ts
@@ -44,7 +44,7 @@ declare module 'vue' {
         uLine: (typeof import('../components/u-line/u-line.vue'))['default'];
         uLineProgress: (typeof import('../components/u-line-progress/u-line-progress.vue'))['default'];
         uLink: (typeof import('../components/u-link/u-link.vue'))['default'];
-        uLoadMore: (typeof import('../components/u-loadmore/u-loadmore.vue'))['default'];
+        uLoadmore: (typeof import('../components/u-loadmore/u-loadmore.vue'))['default'];
         uLoading: (typeof import('../components/u-loading/u-loading.vue'))['default'];
         uLoadingPopup: (typeof import('../components/u-loading-popup/u-loading-popup.vue'))['default'];
         uMask: (typeof import('../components/u-mask/u-mask.vue'))['default'];


### PR DESCRIPTION
组件声明文件中uLoadMore应统一为uLoadmore以保持命名一致性

uview内部的命名和api有点乱，有很多不合理的地方，比如这个组件的命名，`load-more`会更合理一点