### PR TITLE
feat(switch): 增强开关组件支持自定义值类型

### DIFF
--- a/src/pages/componentsB/switch/index.vue
+++ b/src/pages/componentsB/switch/index.vue
@@ -6,15 +6,17 @@
                     <view class="u-demo-title">演示效果</view>
                     <view class="u-demo-area">
                         <u-switch
-                            v-model="checked"
+                            v-model="modelValue"
                             :loading="loading"
                             :size="size"
                             @change="change"
                             :active-color="activeColor"
                             :disabled="disabled"
-                            :activeValue="100"
-                            :inactiveValue="1"
+                            :activeValue="activeValue"
+                            :inactiveValue="inactiveValue"
                         ></u-switch>
+                        <view>当前开关状态: {{ isChecked }}</view>
+                        <view>当前v-model: {{ modelValue }}</view>
                     </view>
                 </view>
                 <view class="u-config-wrap">
@@ -53,10 +55,15 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { $u } from '@/uni_modules/uview-pro';
 
-const checked = ref(false);
+type IModelValue = 1 | 100;
+
+const activeValue = ref<IModelValue>(100);
+const inactiveValue = ref<IModelValue>(1);
+const modelValue = ref<IModelValue>(1);
+const isChecked = computed<boolean>(() => modelValue.value === activeValue.value);
 const activeColor = ref($u.color.primary);
 const size = ref<number | string>(50);
 const loading = ref(false);
@@ -64,7 +71,11 @@ const disabled = ref(false);
 
 function modelChange(index: number) {
     // 两个!!可以把0变成false，1变成true
-    checked.value = !!index;
+    modelValueChange(!!index);
+}
+
+function modelValueChange(value: boolean) {
+    modelValue.value = value ? activeValue.value : inactiveValue.value;
 }
 
 function colorChange(index: number) {
@@ -85,29 +96,27 @@ function disabledChange(index: number) {
 }
 
 function asyncChange(index: number) {
-    if (checked.value && index === 1) {
+    if (isChecked.value && index === 1) {
         $u.toast('请先关闭选择器');
         return;
     }
-    if (!checked.value && index === 0) {
+    if (!isChecked.value && index === 0) {
         $u.toast('请先打开选择器');
         return;
     }
     const str = index === 0 ? '是否要关闭？' : '是否要打开？';
     loading.value = true;
-    const oldStatus = checked.value;
-    checked.value = true;
+    const oldStatus = isChecked.value;
+    modelValueChange(true);
     uni.showModal({
         title: '提示',
         content: str,
         complete: (res: { confirm: boolean }) => {
             loading.value = false;
             if (res.confirm) {
-                if (oldStatus) checked.value = false;
-                else checked.value = true;
+                modelValueChange(!oldStatus);
             } else {
-                if (!oldStatus) checked.value = false;
-                else checked.value = true;
+                modelValueChange(!!oldStatus);
             }
         }
     });

--- a/src/uni_modules/uview-pro/components/u-switch/types.ts
+++ b/src/uni_modules/uview-pro/components/u-switch/types.ts
@@ -18,8 +18,8 @@ export const SwitchProps = {
     activeColor: { type: String, default: () => getColor('primary') },
     /** 关闭时的颜色 */
     inactiveColor: { type: String, default: 'var(--u-white-color)' },
-    /** v-model 绑定值，是否选中 */
-    modelValue: { type: Boolean, default: false },
+    /** v-model 绑定值，开关状态值 */
+    modelValue: { type: [Number, String, Boolean] as PropType<number | string | boolean>, default: false },
     /** 是否开启轻微震动反馈 */
     vibrateShort: { type: Boolean, default: false },
     /** 打开时的值 */

--- a/src/uni_modules/uview-pro/components/u-switch/u-switch.vue
+++ b/src/uni_modules/uview-pro/components/u-switch/u-switch.vue
@@ -1,7 +1,7 @@
 <template>
     <view
         class="u-switch"
-        :class="[modelValue == true ? 'u-switch--on' : '', disabled ? 'u-switch--disabled' : '', customClass]"
+        :class="[isChecked ? 'u-switch--on' : '', disabled ? 'u-switch--disabled' : '', customClass]"
         @tap="onClick"
         :style="$u.toStyle(switchStyle, customStyle)"
     >
@@ -54,19 +54,27 @@ const props = defineProps(SwitchProps);
 const emit = defineEmits(['update:modelValue', 'change']);
 
 /**
+ * 计算属性：是否处于激活状态
+ * 通过比较modelValue和activeValue来确定开关的真实状态
+ */
+const isChecked = computed(() => {
+    return props.modelValue === props.activeValue;
+});
+
+/**
  * 计算开关样式
  */
 const switchStyle = computed(() => {
     let style: Record<string, string> = {};
     style.fontSize = props.size + 'rpx';
-    style.backgroundColor = props.modelValue ? props.activeColor : props.inactiveColor;
+    style.backgroundColor = isChecked.value ? props.activeColor : props.inactiveColor;
     return style;
 });
 /**
  * 计算加载动画颜色
  */
 const loadingColor = computed(() => {
-    return props.modelValue ? props.activeColor : null;
+    return isChecked.value ? props.activeColor : null;
 });
 
 /**
@@ -76,10 +84,13 @@ function onClick() {
     if (!props.disabled && !props.loading) {
         // 使手机产生短促震动，微信小程序有效，APP(HX 2.6.8)和H5无效
         if (props.vibrateShort) uni.vibrateShort();
-        emit('update:modelValue', !props.modelValue);
+
+        // 根据当前状态切换到另一个值
+        const newValue = isChecked.value ? props.inactiveValue : props.activeValue;
+        emit('update:modelValue', newValue);
         // 放到下一个生命周期，因为双向绑定的value修改父组件状态需要时间，且是异步的
         nextTick(() => {
-            emit('change', props.modelValue ? props.activeValue : props.inactiveValue);
+            emit('change', newValue);
         });
     }
 }
@@ -113,11 +124,6 @@ function onClick() {
     border-radius: 100%;
     z-index: 1;
     background-color: var(--u-bg-white);
-    background-color: var(--u-bg-white);
-    box-shadow:
-        0 3px 1px 0 rgba(0, 0, 0, 0.05),
-        0 2px 2px 0 rgba(0, 0, 0, 0.1),
-        0 3px 3px 0 rgba(0, 0, 0, 0.05);
     box-shadow:
         0 3px 1px 0 rgba(0, 0, 0, 0.05),
         0 2px 2px 0 rgba(0, 0, 0, 0.1),


### PR DESCRIPTION
扩展开关组件功能，使其支持number/string/boolean类型的自定义值。主要修改包括：
1. 修改modelValue类型为支持多种类型
2. 添加isChecked计算属性判断真实状态
3. 更新状态切换逻辑以支持自定义值
4. 同步更新示例页面展示新功能


参考 [element-plus](https://element-plus.org/zh-CN/component/switch#api) 的switch API设计，model-value应该是需要和active-value和inactive-value联动的，但是直接这样改可能会造成破坏性更新 @anyup 