### PR TITLE
fix(form): 修复field实例销毁时没有正常移除问题

### DIFF
--- a/src/uni_modules/uview-pro/components/u-form/u-form.vue
+++ b/src/uni_modules/uview-pro/components/u-form/u-form.vue
@@ -121,7 +121,7 @@ defineExpose({
         if (!fields.value.includes(field)) fields.value.push(field);
     },
     removeField(field: any) {
-        fields.value = fields.value.filter(f => f !== field);
+        fields.value = fields.value.filter(f => f.prop !== field.prop)
     },
     fields,
     rules,


### PR DESCRIPTION
form-item销毁时没有移除实例，导致校验异常