### PR TITLE
fix(docs): 修复icon 预览复制失败

### DIFF
--- a/src/pages/componentsA/icon/index.vue
+++ b/src/pages/componentsA/icon/index.vue
@@ -608,26 +608,6 @@ const iconList = ref([
 ]);
 
 const selectIcon = (name: string) => {
-    // #ifdef H5
-    if (typeof navigator !== 'undefined' && navigator.clipboard) {
-        navigator.clipboard
-            .writeText(name)
-            .then(() => {
-                uni.showToast({
-                    title: '图标名称已复制',
-                    icon: 'none'
-                });
-            })
-            .catch(() => {
-                uni.showToast({
-                    title: '复制失败',
-                    icon: 'none'
-                });
-            });
-        return;
-    }
-    // #endif
-    // #ifndef H5
     uni.setClipboardData({
         data: name,
         success: () => {
@@ -635,9 +615,14 @@ const selectIcon = (name: string) => {
                 title: '图标名称已复制',
                 icon: 'none'
             });
+        },
+        fail: () => {
+            uni.showToast({
+                title: '复制失败',
+                icon: 'none'
+            })
         }
     });
-    // #endif
 };
 </script>
 


### PR DESCRIPTION
<img width="391" height="846" alt="image" src="https://github.com/user-attachments/assets/e7fc8215-1cbf-4758-98c5-d7166bf35fc6" />
<img width="734" height="97" alt="image" src="https://github.com/user-attachments/assets/afefb623-350a-43d9-a6f5-d52916560617" />

修复 文档 icon复制失败的问题