### PR TITLE
feat: 新增 ColorPicker 颜色选择器

### DIFF
--- a/src/pages.json
+++ b/src/pages.json
@@ -883,6 +883,13 @@
                         "navigationBarTitleText": "SwipeAction 左滑删除"
                     }
                 },
+                // colorPicker-颜色选择器
+                {
+                    "path": "colorPicker/index",
+                    "style": {
+                        "navigationBarTitleText": "ColorPicker 颜色选择器"
+                    }
+                },
                 {
                     "path": "transition/index",
                     "style": {

--- a/src/pages/componentsB/colorPicker/index.vue
+++ b/src/pages/componentsB/colorPicker/index.vue
@@ -1,0 +1,301 @@
+<template>
+    <demo-page
+        title="ColorPicker 颜色选择器"
+        desc="用于颜色选择，支持弹窗和内联两种模式，可选择单色或渐变色，支持透明度、吸管、历史记录和预设颜色。"
+        :apis="'color-picker'"
+    >
+        <template #default>
+            <view class="u-demo">
+                <!-- 弹窗模式 -->
+                <view class="u-demo-wrap">
+                    <view class="u-demo-title">弹窗模式</view>
+                    <view class="u-demo-area">
+                        <view class="demo-preview-row">
+                            <u-color-picker
+                                :show="popupShow"
+                                v-model="popupColor"
+                                :colorMode="popupColorMode"
+                                :showAlpha="popupShowAlpha"
+                                :showEyeDropper="true"
+                                :showHistory="popupShowHistory"
+                                :showPresets="popupShowPresets"
+                                :shape="popupShape"
+                                @confirm="onPopupConfirm"
+                                @cancel="popupShow = false"
+                                @update:show="(val: boolean) => (popupShow = val)"
+                            ></u-color-picker>
+                            <view class="demo-result">
+                                <view class="demo-color-block" :style="{ background: popupColor }"></view>
+                                <text class="demo-color-value">{{ popupColor }}</text>
+                            </view>
+                        </view>
+                        <u-button type="primary" shape="circle" @click="popupShow = true">打开颜色选择器</u-button>
+                    </view>
+                </view>
+
+                <!-- 内联模式 -->
+                <view class="u-demo-wrap">
+                    <view class="u-demo-title">内联模式</view>
+                    <view class="u-demo-area">
+                        <u-color-picker
+                            v-model="inlineColor"
+                            mode="inline"
+                            :colorMode="inlineColorMode"
+                            :showAlpha="inlineShowAlpha"
+                            :showEyeDropper="true"
+                            :showHistory="inlineShowHistory"
+                            :showPresets="inlineShowPresets"
+                            @change="onInlineChange"
+                        ></u-color-picker>
+                        <view class="demo-result" style="margin-top: 20rpx">
+                            <text class="demo-label">当前颜色：</text>
+                            <text class="demo-color-value">{{ inlineColor }}</text>
+                        </view>
+                    </view>
+                </view>
+
+                <!-- 仅单色模式 -->
+                <view class="u-demo-wrap">
+                    <view class="u-demo-title">仅单色模式（无渐变）</view>
+                    <view class="u-demo-area">
+                        <u-color-picker
+                            :show="solidShow"
+                            v-model="solidColor"
+                            colorMode="solid"
+                            :showAlpha="true"
+                            @confirm="solidShow = false"
+                            @cancel="solidShow = false"
+                            @update:show="(val: boolean) => (solidShow = val)"
+                        ></u-color-picker>
+                        <view class="demo-result">
+                            <view class="demo-color-block" :style="{ background: solidColor }"></view>
+                            <text class="demo-color-value">{{ solidColor }}</text>
+                        </view>
+                        <u-button type="primary" shape="circle" @click="solidShow = true" style="margin-top: 20rpx">
+                            选择单色
+                        </u-button>
+                    </view>
+                </view>
+
+                <!-- 圆形触发器 -->
+                <view class="u-demo-wrap">
+                    <view class="u-demo-title">圆形触发器</view>
+                    <view class="u-demo-area">
+                        <u-color-picker
+                            :show="circleShow"
+                            v-model="circleColor"
+                            shape="circle"
+                            size="80rpx"
+                            @confirm="circleShow = false"
+                            @cancel="circleShow = false"
+                            @update:show="(val: boolean) => (circleShow = val)"
+                        ></u-color-picker>
+                        <text class="demo-color-value" style="margin-top: 20rpx; display: block">{{
+                            circleColor
+                        }}</text>
+                    </view>
+                </view>
+
+                <!-- 使用 u-color-select-panel 直接嵌入 -->
+                <view class="u-demo-wrap">
+                    <view class="u-demo-title">直接使用颜色选择面板</view>
+                    <view class="u-demo-area">
+                        <u-color-select-panel
+                            v-model="panelColor"
+                            :showEyeDropper="true"
+                            :showHistory="true"
+                            :showPresets="true"
+                            @change="onPanelChange"
+                        ></u-color-select-panel>
+                    </view>
+                </view>
+
+                <!-- 参数配置 -->
+                <view class="u-config-wrap">
+                    <view class="u-config-title u-border-bottom">弹窗模式参数配置</view>
+                    <view class="u-config-item">
+                        <view class="u-item-title">颜色模式</view>
+                        <u-subsection
+                            :list="['全部', '纯色', '渐变']"
+                            :current="popupColorModeIndex"
+                            @change="popupColorModeChange"
+                        ></u-subsection>
+                    </view>
+                    <view class="u-config-item">
+                        <view class="u-item-title">显示透明度</view>
+                        <u-subsection
+                            :list="['显示', '隐藏']"
+                            :current="popupShowAlpha ? 0 : 1"
+                            @change="popupShowAlphaChange"
+                        ></u-subsection>
+                    </view>
+                    <view class="u-config-item">
+                        <view class="u-item-title">显示历史记录</view>
+                        <u-subsection
+                            :list="['显示', '隐藏']"
+                            :current="popupShowHistory ? 0 : 1"
+                            @change="popupShowHistoryChange"
+                        ></u-subsection>
+                    </view>
+                    <view class="u-config-item">
+                        <view class="u-item-title">显示预设颜色</view>
+                        <u-subsection
+                            :list="['显示', '隐藏']"
+                            :current="popupShowPresets ? 0 : 1"
+                            @change="popupShowPresetsChange"
+                        ></u-subsection>
+                    </view>
+                    <view class="u-config-item">
+                        <view class="u-item-title">触发器形状</view>
+                        <u-subsection
+                            :list="['方形', '圆形']"
+                            :current="popupShape === 'square' ? 0 : 1"
+                            @change="popupShapeChange"
+                        ></u-subsection>
+                    </view>
+                </view>
+            </view>
+        </template>
+    </demo-page>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const popupShow = ref(false);
+const popupColor = ref('#2979ff');
+const popupColorMode = ref<string>('both');
+const popupShowAlpha = ref(true);
+const popupShowHistory = ref(true);
+const popupShowPresets = ref(true);
+const popupShape = ref<'square' | 'circle'>('square');
+
+const popupColorModeIndex = ref(0);
+
+const inlineColor = ref('#ff6b6b');
+const inlineColorMode = ref('both');
+const inlineShowAlpha = ref(true);
+const inlineShowHistory = ref(true);
+const inlineShowPresets = ref(true);
+
+const solidShow = ref(false);
+const solidColor = ref('#00c853');
+
+const circleShow = ref(false);
+const circleColor = ref('#e040fb');
+
+const panelColor = ref('#ff9800');
+
+function onPopupConfirm(color: string) {
+    console.log('弹窗模式确认颜色：', color);
+}
+
+function onInlineChange(color: string) {
+    console.log('内联模式颜色变化：', color);
+}
+
+function onPanelChange(color: string) {
+    console.log('面板颜色变化：', color);
+}
+
+function popupColorModeChange(index: number) {
+    const modes = ['both', 'solid', 'gradient'];
+    popupColorMode.value = modes[index];
+    popupColorModeIndex.value = index;
+}
+
+function popupShowAlphaChange(index: number) {
+    popupShowAlpha.value = index === 0;
+}
+
+function popupShowHistoryChange(index: number) {
+    popupShowHistory.value = index === 0;
+}
+
+function popupShowPresetsChange(index: number) {
+    popupShowPresets.value = index === 0;
+}
+
+function popupShapeChange(index: number) {
+    popupShape.value = index === 0 ? 'square' : 'circle';
+}
+</script>
+
+<style lang="scss">
+.u-demo-wrap {
+    background-color: var(--u-bg-white);
+    padding: 40rpx 8rpx;
+    margin-left: -14rpx;
+    margin-right: -14rpx;
+    margin-bottom: 20rpx;
+}
+
+.u-demo-title {
+    font-size: 28rpx;
+    font-weight: bold;
+    color: var(--u-main-color);
+    margin-bottom: 20rpx;
+}
+
+.u-demo-area {
+    padding: 10rpx 0;
+}
+
+.demo-preview-row {
+    display: flex;
+    align-items: center;
+    gap: 20rpx;
+    margin-bottom: 20rpx;
+    flex-wrap: wrap;
+}
+
+.demo-result {
+    display: flex;
+    align-items: center;
+    gap: 16rpx;
+}
+
+.demo-color-block {
+    width: 80rpx;
+    height: 80rpx;
+    border-radius: 12rpx;
+    border: 1px solid var(--u-border-color);
+}
+
+.demo-color-value {
+    font-size: 28rpx;
+    color: var(--u-content-color);
+    font-family: monospace;
+}
+
+.demo-label {
+    font-size: 28rpx;
+    color: var(--u-main-color);
+}
+
+.u-config-wrap {
+    background-color: var(--u-bg-white);
+    padding: 30rpx 20rpx;
+    border-radius: 16rpx;
+    margin-bottom: 30rpx;
+}
+
+.u-config-title {
+    font-size: 32rpx;
+    font-weight: bold;
+    color: var(--u-main-color);
+    padding-bottom: 24rpx;
+    margin-bottom: 24rpx;
+    border-bottom: 1px solid var(--u-divider-color);
+}
+
+.u-config-item {
+    margin-top: 30rpx;
+}
+
+.u-item-title {
+    font-size: 28rpx;
+    color: var(--u-tips-color);
+    margin-bottom: 16rpx;
+}
+</style>

--- a/src/pages/example/components.config.ts
+++ b/src/pages/example/components.config.ts
@@ -220,6 +220,14 @@ export default [
                 desc_en: 'Switch component for binary state toggling and instant interactions.'
             },
             {
+                path: '/pages/componentsB/colorPicker/index',
+                icon: 'color',
+                title: 'ColorPicker 颜色选择器',
+                title_en: 'ColorPicker',
+                desc: '颜色选择器，支持弹窗和内联模式，可选择单色或渐变色。',
+                desc_en: 'Color picker with popup/inline modes for solid and gradient colors.'
+            },
+            {
                 path: '/pages/componentsA/slider/index',
                 icon: 'slider',
                 title: 'Slider 滑动选择器',

--- a/src/uni_modules/uview-pro/components/u-color-picker/README.md
+++ b/src/uni_modules/uview-pro/components/u-color-picker/README.md
@@ -1,0 +1,216 @@
+# ColorPicker 颜色选择器
+
+该组件用于颜色选择，包含弹窗模式（`u-color-picker`）和内联面板模式（`u-color-select-panel`）两个组件，支持单色、渐变色、透明度调节、历史记录、预设颜色、吸管取色等功能，可根据场景灵活使用。
+
+## 平台差异说明
+
+| App | H5 | 微信小程序 | 支付宝小程序 | 百度小程序 | 头条小程序 | QQ小程序 |
+| :--: | :--: | :--: | :--: | :--: | :--: | :--: |
+| √ | √ | √ | √ | √ | √ | √ |
+
+> 注意：吸管取色（EyeDropper）功能仅在支持 `EyeDropper API` 的浏览器环境（如 Chrome Desktop）中可用，小程序和移动端 H5 环境暂不支持。
+
+## 基本使用
+
+### 弹窗模式
+
+使用 `u-color-picker` 组件，通过 `v-model:show` 控制弹窗显隐，`v-model` 双向绑定颜色值。
+
+```html
+<template>
+    <view>
+        <u-button @click="showPicker = true">打开颜色选择器</u-button>
+        <view :style="{ background: color, width: '100px', height: '100px' }"></view>
+
+        <u-color-picker
+            :show="showPicker"
+            v-model="color"
+            @confirm="onConfirm"
+            @cancel="showPicker = false"
+        ></u-color-picker>
+    </view>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+const showPicker = ref(false);
+const color = ref('#2979ff');
+
+const onConfirm = (e) => {
+    console.log('选择的颜色：', e);
+    showPicker.value = false;
+};
+</script>
+```
+
+### 内联模式
+
+使用 `u-color-select-panel` 组件直接嵌入页面，无需弹窗。
+
+```html
+<template>
+    <view class="page">
+        <u-color-select-panel
+            v-model="color"
+            @change="onChange"
+        ></u-color-select-panel>
+    </view>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+const color = ref('#2979ff');
+
+const onChange = (e) => {
+    console.log('实时颜色变化：', e);
+};
+</script>
+```
+
+### 自定义样式
+
+通过 `customStyle` 和 `customClass` 可自定义组件根节点的样式。
+
+```html
+<template>
+    <u-color-picker
+        v-model="color"
+        :show="show"
+        :customStyle="{ borderRadius: '24rpx' }"
+        customClass="my-custom-picker"
+    ></u-color-picker>
+</template>
+```
+
+## API
+
+### u-color-picker Props
+
+| 参数 | 说明 | 类型 | 默认值 | 可选值 |
+| :-- | :-- | :-- | :-- | :-- |
+| v-model | 绑定的颜色值 | String | `#000000` | - |
+| show | 是否显示弹窗 | Boolean | `false` | - |
+| mode | 显示模式 | String | `popup` | `popup`, `inline` |
+| title | 弹窗标题 | String | `选择颜色` | - |
+| confirmText | 确认按钮文字 | String | `确定` | - |
+| cancelText | 取消按钮文字 | String | `取消` | - |
+| shape | 触发器形状 | String | `square` | `square`, `circle` |
+| size | 触发器大小 | String \| Number | `60rpx` | - |
+| zIndex | 弹窗层级 | String \| Number | `10075` | - |
+| colorMode | 颜色模式 | String | `both` | `solid`, `gradient`, `both` |
+| showAlpha | 是否显示透明度调节 | Boolean | `true` | `true`, `false` |
+| showEyeDropper | 是否显示吸管工具 | Boolean | `true` | `true`, `false` |
+| showHistory | 是否显示最近使用颜色 | Boolean | `true` | `true`, `false` |
+| showPresets | 是否显示预设颜色 | Boolean | `true` | `true`, `false` |
+| presets | 预设颜色列表 | Array | `[...]` | - |
+| format | 颜色格式 | String | `HEX` | `HEX`, `RGB` |
+| disabled | 是否禁用 | Boolean | `false` | - |
+| customStyle | 自定义根节点样式 | Object \| String | `{}` | - |
+| customClass | 自定义根节点样式类 | String | `''` | - |
+
+### u-color-picker Events
+
+| 事件名 | 说明 | 回调参数 |
+| :-- | :-- | :-- |
+| confirm | 点击确定按钮触发 | `color: string` |
+| cancel | 点击取消或关闭弹窗触发 | - |
+| change | 颜色改变时实时触发 | `color: string` |
+| color-update | 颜色每次更新时触发 | `color: string` |
+| update:modelValue | 颜色值变化时触发（v-model） | `color: string` |
+| update:show | 弹窗显隐状态变化时触发 | `show: boolean` |
+
+### u-color-select-panel Props
+
+| 参数 | 说明 | 类型 | 默认值 | 可选值 |
+| :-- | :-- | :-- | :-- | :-- |
+| v-model | 绑定的颜色值 | String | `#000000` | - |
+| colorMode | 颜色模式 | String | `both` | `solid`, `gradient`, `both` |
+| showAlpha | 是否显示透明度调节 | Boolean | `true` | `true`, `false` |
+| showEyeDropper | 是否显示吸管工具 | Boolean | `true` | `true`, `false` |
+| showHistory | 是否显示最近使用颜色 | Boolean | `true` | `true`, `false` |
+| showPresets | 是否显示预设颜色 | Boolean | `true` | `true`, `false` |
+| presets | 预设颜色列表 | Array | `[...]` | - |
+| format | 颜色格式 | String | `HEX` | `HEX`, `RGB` |
+| disabled | 是否禁用 | Boolean | `false` | - |
+| customStyle | 自定义根节点样式 | Object \| String | `{}` | - |
+| customClass | 自定义根节点样式类 | String | `''` | - |
+
+### u-color-select-panel Events
+
+| 事件名 | 说明 | 回调参数 |
+| :-- | :-- | :-- |
+| change | 颜色改变时实时触发 | `color: string` |
+| color-update | 颜色每次更新时触发 | `color: string` |
+| update:modelValue | 颜色值变化时触发（v-model） | `color: string` |
+
+### u-color-select-panel Methods
+
+可通过 `ref` 调用组件内部方法。
+
+| 方法名 | 说明 | 参数 | 返回值 |
+| :-- | :-- | :-- | :-- |
+| setColor | 主动设置颜色 | `color: string` | - |
+| getColor | 获取当前颜色对象详细信息 | - | `ColorObject` |
+| saveRecentColor | 保存指定颜色到历史记录 | `color: string` | - |
+
+#### ColorObject 类型定义
+
+```typescript
+interface ColorObject {
+    hex: string;          // 十六进制颜色值，如 #ff0000ff
+    rgb: {                // RGB 对象
+        r: number;
+        g: number;
+        b: number;
+    };
+    hsl: {                // HSL 对象
+        h: number;
+        s: number;
+        l: number;
+    };
+    hsv: {                // HSV 对象
+        h: number;
+        s: number;
+        v: number;
+    };
+    alpha: number;        // 透明度 0-1
+    source: string;       // 来源格式 'hex' | 'rgb' | 'hsl'
+}
+```
+
+## 功能特性详解
+
+### 1. 渐变色支持
+
+当 `colorMode` 设置为 `gradient` 或 `both` 时，组件支持 CSS 线性渐变（linear-gradient）。
+
+- 面板顶部会出现渐变控制条，可添加/选择颜色断点（Stop）
+- 点击断点可选中，选中的断点会放大高亮显示
+- 拖动断点可调整其在渐变中的位置
+- 选中断点后，下方选色区域将控制该断点的颜色
+- v-model 的值在渐变模式下为 `linear-gradient(90deg, #fff 0%, #000 100%)` 格式
+
+### 2. 颜色格式切换
+
+点击输入框左侧的格式标签可以切换颜色显示格式。
+
+- HEX：支持 6 位（`#RRGGBB`）和 8 位（`#RRGGBBAA`）格式
+- RGB：显示为 `rgba(r, g, b, a)` 格式
+
+### 3. 吸管工具 (EyeDropper)
+
+在支持 `EyeDropper API` 的 H5 环境（桌面端 Chrome/Edge），点击吸管图标可以吸取屏幕上任意位置的颜色。移动端 H5 或小程序环境暂不支持此 API，吸管按钮会自动隐藏。
+
+### 4. 历史记录
+
+组件会自动保存最近使用的 10 个颜色到本地存储，方便快速复用。可通过 `showHistory` 控制是否显示历史记录区域，通过 `saveRecentColor` 方法手动保存颜色。
+
+### 5. 预设颜色
+
+支持通过 `presets` 属性自定义预设颜色列表，组件内置了 15 种常用颜色作为默认值。可通过 `showPresets` 控制是否显示预设颜色区域。
+
+### 6. 暗黑模式适配
+
+组件内置了对暗黑模式的支持，会自动感知当前应用的主题设置并切换相应的背景色和文字颜色。无需额外配置。

--- a/src/uni_modules/uview-pro/components/u-color-picker/types.ts
+++ b/src/uni_modules/uview-pro/components/u-color-picker/types.ts
@@ -1,0 +1,66 @@
+import type { ExtractPropTypes, PropType } from 'vue';
+import { useLocale } from '../../';
+import { ColorSelectPanelProps } from '../u-color-select-panel/types';
+
+const { t } = useLocale();
+
+export const ColorPickerProps = {
+    ...ColorSelectPanelProps,
+    /** 自定义根节点样式 */
+    customStyle: {
+        type: [String, Object] as PropType<string | Record<string, any>>,
+        default: () => ({})
+    },
+    /** 自定义根节点样式类 */
+    customClass: {
+        type: String as unknown as PropType<string>,
+        default: ''
+    },
+    /** 是否显示弹窗 */
+    show: {
+        type: Boolean,
+        default: false
+    },
+    /** 模式：popup-弹窗，inline-内联 */
+    mode: {
+        type: String as PropType<'popup' | 'inline'>,
+        default: 'popup'
+    },
+    /** 标题 */
+    title: {
+        type: String,
+        default: () => t('uColorPicker.title')
+    },
+    /** 确认按钮文字 */
+    confirmText: {
+        type: String,
+        default: () => t('uColorPicker.confirmText')
+    },
+    /** 取消按钮文字 */
+    cancelText: {
+        type: String,
+        default: () => t('uColorPicker.cancelText')
+    },
+    /** z-index */
+    zIndex: {
+        type: [String, Number],
+        default: 10075
+    },
+    /** 形状：square-方形，circle-圆形 */
+    shape: {
+        type: String as PropType<'square' | 'circle'>,
+        default: 'square'
+    },
+    /** 大小 */
+    size: {
+        type: [String, Number],
+        default: '60rpx'
+    },
+    /** 是否禁用 */
+    disabled: {
+        type: Boolean,
+        default: false
+    }
+};
+
+export type ColorPickerProps = ExtractPropTypes<typeof ColorPickerProps>;

--- a/src/uni_modules/uview-pro/components/u-color-picker/u-color-picker.vue
+++ b/src/uni_modules/uview-pro/components/u-color-picker/u-color-picker.vue
@@ -1,0 +1,330 @@
+<template>
+    <view class="u-color-picker" :class="[customClass]" :style="$u.toStyle(customStyle)">
+        <!-- 触发器 (仅弹窗模式) -->
+        <view
+            v-if="props.mode === 'popup'"
+            class="u-color-picker__trigger"
+            :class="[
+                `u-color-picker__trigger--${props.shape}`,
+                { 'u-color-picker__trigger--disabled': props.disabled }
+            ]"
+            :style="{
+                width: props.size,
+                height: props.size
+            }"
+            @tap="open"
+        >
+            <view class="u-color-picker__trigger__color" :style="{ background: props.modelValue }">
+                <u-icon name="arrow-down" color="#fff" size="12" v-if="!props.modelValue"></u-icon>
+            </view>
+            <view class="u-color-picker__trigger__icon">
+                <u-icon name="arrow-down" size="14" :color="isLightColor(props.modelValue) ? '#000' : '#fff'"></u-icon>
+            </view>
+        </view>
+
+        <!-- 弹窗模式 -->
+        <u-popup
+            v-if="props.mode === 'popup'"
+            :show="props.show"
+            :modelValue="props.show"
+            @close="close"
+            @update:modelValue="(val: boolean) => emit('update:show', val)"
+            mode="bottom"
+            :round="24"
+            :z-index="props.zIndex"
+            :safeAreaInsetBottom="true"
+            :customStyle="{ backgroundColor: 'transparent' }"
+        >
+            <view class="u-color-picker__content">
+                <view class="u-color-picker__header">
+                    <text class="u-color-picker__header__title">{{ props.title }}</text>
+                    <view class="u-color-picker__header__close" @tap="close">
+                        <u-icon name="close" size="32" color="#909399"></u-icon>
+                    </view>
+                </view>
+
+                <view class="u-color-picker__body">
+                    <u-color-select-panel
+                        ref="panelRef"
+                        :modelValue="props.modelValue"
+                        :colorMode="props.colorMode"
+                        :showAlpha="props.showAlpha"
+                        :showEyeDropper="props.showEyeDropper"
+                        :showHistory="props.showHistory"
+                        :showPresets="props.showPresets"
+                        :presets="props.presets"
+                        :disabled="props.disabled"
+                        @update:modelValue="onPanelUpdate"
+                        @change="onPanelChange"
+                        @color-update="onColorUpdate"
+                    ></u-color-select-panel>
+
+                    <!-- Footer -->
+                    <view class="u-color-picker__footer">
+                        <u-button
+                            type="primary"
+                            shape="circle"
+                            :customStyle="{ width: '100%', height: '88rpx', fontSize: '32rpx' }"
+                            @click="confirm"
+                            >{{ props.confirmText }}</u-button
+                        >
+                    </view>
+                </view>
+            </view>
+        </u-popup>
+
+        <!-- 内联模式 -->
+        <view v-else class="u-color-picker__content u-color-picker__content--inline">
+            <view class="u-color-picker__body">
+                <u-color-select-panel
+                    ref="panelRef"
+                    :modelValue="props.modelValue"
+                    :colorMode="props.colorMode"
+                    :showAlpha="props.showAlpha"
+                    :showEyeDropper="props.showEyeDropper"
+                    :showHistory="props.showHistory"
+                    :showPresets="props.showPresets"
+                    :presets="props.presets"
+                    :format="props.format"
+                    :disabled="props.disabled"
+                    @update:modelValue="onPanelUpdate"
+                    @change="onPanelChange"
+                    @color-update="onColorUpdate"
+                ></u-color-select-panel>
+            </view>
+        </view>
+    </view>
+</template>
+
+<script lang="ts">
+export default {
+    name: 'u-color-picker',
+    options: {
+        addGlobalClass: true,
+        // #ifndef MP-TOUTIAO
+        virtualHost: true,
+        // #endif
+        styleIsolation: 'shared'
+    }
+};
+</script>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { $u } from '../../';
+import { ColorPickerProps } from './types';
+import UColorSelectPanel from '../u-color-select-panel/u-color-select-panel.vue';
+
+/**
+ * color-picker 颜色选择器
+ * @description 颜色选择器组件，支持弹窗模式和内联模式，可选择单色或渐变色，支持透明度、吸管、历史记录和预设颜色
+ * @tutorial https://uviewpro.cn/zh/components/color-picker.html
+ * @property {String} modelValue 绑定的颜色值（默认#000000）
+ * @property {'popup' | 'inline'} mode 模式：popup-弹窗，inline-内联（默认popup）
+ * @property {String} title 弹窗标题
+ * @property {String} confirmText 确认按钮文字
+ * @property {String} cancelText 取消按钮文字
+ * @property {Number | String} zIndex 弹窗层级（默认10075）
+ * @property {'square' | 'circle'} shape 触发器形状（默认square）
+ * @property {String | Number} size 触发器大小（默认60rpx）
+ * @property {Boolean} disabled 是否禁用
+ * @event update:modelValue 颜色值变化时触发
+ * @event update:show 弹窗显示状态变化时触发
+ * @event confirm 点击确认按钮时触发
+ * @event cancel 关闭弹窗时触发
+ * @event change 颜色变化时触发
+ * @event color-update 颜色更新时触发
+ * @example <u-color-picker v-model="color" mode="popup" />
+ */
+const props = defineProps(ColorPickerProps);
+const emit = defineEmits(['update:modelValue', 'update:show', 'confirm', 'cancel', 'change', 'color-update']);
+
+const isLightColor = (color: string) => {
+    if (!color) return true;
+
+    // Simple check for light colors to adjust icon color
+    let r = 0,
+        g = 0,
+        b = 0;
+
+    // Hex
+    if (color.startsWith('#')) {
+        const hex = color.replace('#', '');
+        if (hex.length === 3) {
+            r = parseInt(hex[0] + hex[0], 16);
+            g = parseInt(hex[1] + hex[1], 16);
+            b = parseInt(hex[2] + hex[2], 16);
+        } else if (hex.length >= 6) {
+            r = parseInt(hex.substring(0, 2), 16);
+            g = parseInt(hex.substring(2, 4), 16);
+            b = parseInt(hex.substring(4, 6), 16);
+        }
+    }
+    // RGB/RGBA
+    else if (color.startsWith('rgb')) {
+        const parts = color.match(/\d+/g);
+        if (parts && parts.length >= 3) {
+            r = parseInt(parts[0]);
+            g = parseInt(parts[1]);
+            b = parseInt(parts[2]);
+        }
+    }
+
+    // Calculate luminance
+    // Y = 0.299R + 0.587G + 0.114B
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+    return luminance > 0.5;
+};
+
+const panelRef = ref<InstanceType<typeof UColorSelectPanel> | null>(null);
+const tempColor = ref(props.modelValue || '#000000');
+
+const open = () => {
+    if (props.disabled) return;
+    emit('update:show', true);
+};
+
+const onPanelUpdate = (val: string) => {
+    tempColor.value = val;
+    if (props.mode === 'inline') {
+        emit('update:modelValue', val);
+    }
+};
+
+const onPanelChange = (val: string) => {
+    emit('change', val);
+};
+
+const onColorUpdate = (val: string) => {
+    emit('color-update', val);
+};
+
+const close = () => {
+    emit('update:show', false);
+    emit('cancel');
+};
+
+const confirm = () => {
+    if (panelRef.value) {
+        panelRef.value.saveRecentColor(tempColor.value);
+    }
+    emit('update:modelValue', tempColor.value);
+    emit('confirm', tempColor.value);
+    emit('update:show', false);
+};
+
+watch(
+    () => props.modelValue,
+    val => {
+        tempColor.value = val;
+    }
+);
+</script>
+
+<style lang="scss" scoped>
+@import 'uview-pro/libs/css/style.components.scss';
+
+.u-color-picker {
+    &__trigger {
+        border: 1px solid var(--u-border-color);
+        background-color: var(--u-bg-color);
+        box-sizing: border-box;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: opacity 0.3s;
+        padding: 4rpx;
+        position: relative;
+
+        &--square {
+            border-radius: 8rpx;
+            .u-color-picker__trigger__color {
+                border-radius: 6rpx;
+            }
+        }
+        &--circle {
+            border-radius: 50%;
+            .u-color-picker__trigger__color {
+                border-radius: 50%;
+            }
+        }
+        &--disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        &__color {
+            width: 100%;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            overflow: hidden;
+        }
+
+        &__icon {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            z-index: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: transparent;
+            box-shadow: none;
+            padding: 0;
+            border-radius: 0;
+        }
+    }
+
+    &__content {
+        background-color: var(--u-bg-color);
+        color: var(--u-text-color);
+        border-top-left-radius: 24rpx;
+        border-top-right-radius: 24rpx;
+        overflow: hidden;
+
+        &--inline {
+            background-color: var(--u-bg-color);
+            border-radius: 16rpx;
+            overflow: hidden;
+            border: 1px solid var(--u-border-color);
+        }
+    }
+
+    &__header {
+        position: relative;
+        @include vue-flex;
+        align-items: center;
+        justify-content: center;
+        height: 88rpx;
+        padding: 0 24rpx;
+        border-bottom: 1px solid var(--u-divider-color);
+        background-color: var(--u-bg-color);
+
+        &__title {
+            font-size: 30rpx;
+            font-weight: bold;
+            color: var(--u-text-color);
+        }
+
+        &__close {
+            position: absolute;
+            right: 30rpx;
+            padding: 10rpx;
+        }
+    }
+
+    &__body {
+        padding: 0; // Padding handled by panel
+        background-color: var(--u-bg-color);
+    }
+
+    &__footer {
+        padding: 24rpx;
+        border-top: 1px solid var(--u-divider-color);
+        background-color: var(--u-bg-color);
+    }
+}
+</style>

--- a/src/uni_modules/uview-pro/components/u-color-select-panel/types.ts
+++ b/src/uni_modules/uview-pro/components/u-color-select-panel/types.ts
@@ -1,0 +1,86 @@
+import type { ExtractPropTypes, PropType } from 'vue';
+
+export const ColorSelectPanelProps = {
+    /** 自定义根节点样式 */
+    customStyle: {
+        type: [String, Object] as PropType<string | Record<string, any>>,
+        default: () => ({})
+    },
+    /** 自定义根节点样式类 */
+    customClass: {
+        type: String as unknown as PropType<string>,
+        default: ''
+    },
+    /** 绑定值 */
+    modelValue: {
+        type: String,
+        default: '#000000'
+    },
+    /** 颜色模式: 'solid'|'gradient'|'both' */
+    colorMode: {
+        type: String as PropType<'solid' | 'gradient' | 'both'>,
+        default: 'both'
+    },
+    /** 是否显示透明度 */
+    showAlpha: {
+        type: Boolean,
+        default: true
+    },
+    /** 是否显示吸管 */
+    showEyeDropper: {
+        type: Boolean,
+        default: true
+    },
+    /** 是否显示历史记录 */
+    showHistory: {
+        type: Boolean,
+        default: true
+    },
+    /** 是否显示预设颜色 */
+    showPresets: {
+        type: Boolean,
+        default: true
+    },
+    /** 预设颜色列表 */
+    presets: {
+        type: Array as PropType<string[]>,
+        default: () => [
+            '#000000',
+            '#ffffff',
+            '#ff0000',
+            '#00ff00',
+            '#0000ff',
+            '#ffff00',
+            '#00ffff',
+            '#ff00ff',
+            '#c0c0c0',
+            '#808080',
+            '#800000',
+            '#800080',
+            '#008000',
+            '#008080',
+            '#000080'
+        ]
+    },
+    /** 格式: 'HEX' | 'RGB' */
+    format: {
+        type: String as PropType<'HEX' | 'RGB'>,
+        default: 'HEX'
+    },
+    /** 是否禁用 */
+    disabled: {
+        type: Boolean,
+        default: false
+    }
+};
+
+export type ColorSelectPanelProps = ExtractPropTypes<typeof ColorSelectPanelProps>;
+
+export interface ColorObject {
+    hex: string;
+    rgb: { r: number; g: number; b: number };
+    hsl: { h: number; s: number; l: number };
+    hsv: { h: number; s: number; v: number };
+    alpha: number;
+    source: string; // 'hex' | 'rgb' | 'hsl'
+}

--- a/src/uni_modules/uview-pro/components/u-color-select-panel/u-color-select-panel.vue
+++ b/src/uni_modules/uview-pro/components/u-color-select-panel/u-color-select-panel.vue
@@ -1,0 +1,1192 @@
+<template>
+    <view class="u-color-select-panel" :class="[customClass]" :style="$u.toStyle(customStyle)">
+        <!-- Tabs -->
+        <view v-if="colorMode === 'both'" class="u-color-select-panel__tabs">
+            <view
+                class="u-color-select-panel__tab-item"
+                :class="{ 'u-color-select-panel__tab-item--active': colorType === 'solid' }"
+                @tap="colorType = 'solid'"
+            >
+                {{ t('uColorSelectPanel.solid') }}
+            </view>
+            <view
+                class="u-color-select-panel__tab-item"
+                :class="{ 'u-color-select-panel__tab-item--active': colorType === 'gradient' }"
+                @tap="colorType = 'gradient'"
+            >
+                {{ t('uColorSelectPanel.gradient') }}
+            </view>
+        </view>
+
+        <!-- Gradient Bar (Only in Gradient Mode) -->
+        <view v-if="colorType === 'gradient'" class="u-color-select-panel__gradient-bar-wrapper">
+            <view class="u-color-select-panel__gradient-bg" />
+            <view
+                id="u-color-select-panel__gradient-bar"
+                class="u-color-select-panel__gradient-bar"
+                :style="{ background: gradientString }"
+                @touchstart.stop.prevent="onGradientTouchStart"
+                @touchmove.stop.prevent="onGradientTouchMove"
+            >
+                <view
+                    v-for="(stop, index) in gradientStops"
+                    :key="index"
+                    class="u-color-select-panel__gradient-stop"
+                    :style="{ left: `${stop.offset * 100}%`, backgroundColor: stop.color }"
+                    :class="{ 'u-color-select-panel__gradient-stop--active': activeGradientIndex === index }"
+                    @tap.stop="selectGradientStop(index)"
+                />
+            </view>
+        </view>
+
+        <!-- SV Box -->
+        <view
+            id="u-color-select-panel__sv-box"
+            class="u-color-select-panel__sv-box"
+            :style="{ backgroundColor: `hsl(${hsv.h}, 100%, 50%)` }"
+            @touchstart.stop.prevent="onSvTouchStart"
+            @touchmove.stop.prevent="onSvTouchMove"
+        >
+            <view class="u-color-select-panel__sv-white" />
+            <view class="u-color-select-panel__sv-black" />
+            <view
+                class="u-color-select-panel__sv-cursor"
+                :style="{
+                    top: `${(1 - hsv.v) * 100}%`,
+                    left: `${hsv.s * 100}%`
+                }"
+            />
+        </view>
+
+        <!-- Middle Row -->
+        <view class="u-color-select-panel__middle-row">
+            <!-- Sliders -->
+            <view class="u-color-select-panel__sliders-col">
+                <view id="u-color-select-panel__hue-slider" class="u-color-select-panel__slider-wrapper">
+                    <view
+                        class="u-color-select-panel__hue-bar"
+                        @touchstart.stop.prevent="onHueTouchStart"
+                        @touchmove.stop.prevent="onHueTouchMove"
+                    >
+                        <view class="u-color-select-panel__slider-thumb" :style="{ left: `${(hsv.h / 360) * 100}%` }" />
+                    </view>
+                </view>
+                <view
+                    v-if="showAlpha"
+                    id="u-color-select-panel__alpha-slider"
+                    class="u-color-select-panel__slider-wrapper"
+                >
+                    <view class="u-color-select-panel__alpha-bg" />
+                    <view
+                        class="u-color-select-panel__alpha-bar"
+                        :style="{
+                            background: `linear-gradient(to right, rgba(${rgb.r},${rgb.g},${rgb.b},0), rgba(${rgb.r},${rgb.g},${rgb.b},1))`
+                        }"
+                        @touchstart.stop.prevent="onAlphaTouchStart"
+                        @touchmove.stop.prevent="onAlphaTouchMove"
+                    >
+                        <view class="u-color-select-panel__slider-thumb" :style="{ left: `${hsv.a * 100}%` }" />
+                    </view>
+                </view>
+            </view>
+            <!-- Preview Block -->
+            <view class="u-color-select-panel__preview-block" :style="{ background: previewColor }" />
+        </view>
+
+        <!-- Input Row -->
+        <view class="u-color-select-panel__input-row">
+            <!-- Format Dropdown -->
+            <view class="u-color-select-panel__format-selector">
+                <view class="u-color-select-panel__format-current" @tap.stop="showFormatDropdown = !showFormatDropdown">
+                    <text>{{ colorFormat }}</text>
+                    <u-icon
+                        name="arrow-down"
+                        size="24"
+                        color="var(--u-main-color)"
+                        :custom-style="{
+                            marginLeft: '4rpx',
+                            transform: showFormatDropdown ? 'rotate(180deg)' : 'rotate(0deg)',
+                            transition: 'transform 0.2s'
+                        }"
+                    />
+                </view>
+                <view v-if="showFormatDropdown" class="u-color-select-panel__format-dropdown">
+                    <view
+                        v-for="fmt in ['HEX', 'RGB']"
+                        :key="fmt"
+                        class="u-color-select-panel__format-option"
+                        :class="{ 'u-color-select-panel__format-option--active': colorFormat === fmt }"
+                        @tap="selectFormat(fmt as 'HEX' | 'RGB')"
+                    >
+                        {{ fmt }}
+                    </view>
+                </view>
+            </view>
+
+            <!-- Color Input -->
+            <view class="u-color-select-panel__input-container">
+                <text v-if="colorFormat === 'HEX'" class="u-color-select-panel__input-prefix"> # </text>
+                <input
+                    v-model="displayColorValue"
+                    class="u-color-select-panel__hex-input"
+                    @blur="onColorInputBlur"
+                    @confirm="onColorInputBlur"
+                />
+            </view>
+
+            <!-- Alpha Input -->
+            <view v-if="showAlpha" class="u-color-select-panel__alpha-control">
+                <view class="u-color-select-panel__alpha-btn" @tap="adjustAlpha(-5)">
+                    <u-icon name="minus" size="20" color="var(--u-main-color)" />
+                </view>
+                <view class="u-color-select-panel__alpha-input-wrapper">
+                    <input
+                        v-model="alphaInputValue"
+                        class="u-color-select-panel__alpha-input"
+                        type="number"
+                        :maxlength="3"
+                        @blur="onAlphaInputBlur"
+                        @confirm="onAlphaInputBlur"
+                    />
+                    <text class="u-color-select-panel__alpha-percent"> % </text>
+                </view>
+                <view class="u-color-select-panel__alpha-btn" @tap="adjustAlpha(5)">
+                    <u-icon name="plus" size="20" color="var(--u-main-color)" />
+                </view>
+            </view>
+
+            <!-- EyeDropper -->
+            <view
+                v-if="showEyeDropper && isEyeDropperSupported"
+                class="u-color-select-panel__eyedropper-btn"
+                @tap="openEyeDropper"
+            >
+                <u-icon name="edit-pen" size="36" color="var(--u-main-color)" />
+            </view>
+        </view>
+
+        <!-- Recent Colors -->
+        <view v-if="showHistory && recentColors.length" class="u-color-select-panel__presets">
+            <text class="u-color-select-panel__section-title"> {{ t('uColorSelectPanel.recentColors') }} </text>
+            <view class="u-color-select-panel__swatches-grid">
+                <view
+                    v-for="(color, index) in recentColors"
+                    :key="`recent-${index}`"
+                    class="u-color-select-panel__swatch"
+                    :style="{ background: color }"
+                    @tap="selectSwatch(color)"
+                />
+            </view>
+        </view>
+
+        <!-- System Presets -->
+        <view v-if="showPresets && presets && presets.length" class="u-color-select-panel__presets">
+            <text class="u-color-select-panel__section-title"> {{ t('uColorSelectPanel.systemPresets') }} </text>
+            <view class="u-color-select-panel__swatches-grid">
+                <view
+                    v-for="(color, index) in presets"
+                    :key="index"
+                    class="u-color-select-panel__swatch"
+                    :style="{ backgroundColor: color }"
+                    @tap="selectSwatch(color)"
+                />
+            </view>
+        </view>
+    </view>
+</template>
+
+<script lang="ts">
+export default {
+    name: 'u-color-select-panel',
+    options: {
+        addGlobalClass: true,
+        // #ifndef MP-TOUTIAO
+        virtualHost: true,
+        // #endif
+        styleIsolation: 'shared'
+    }
+};
+</script>
+
+<script setup lang="ts">
+import type { ColorObject } from './types';
+import { computed, getCurrentInstance, nextTick, onMounted, reactive, ref, watch } from 'vue';
+import { $u, useLocale } from '../..';
+import { ColorSelectPanelProps } from './types';
+
+/**
+ * color-select-panel 颜色选择面板
+ * @description 颜色选择面板组件，支持单色和渐变色选择、透明度调节、吸管取色、历史记录和预设颜色
+ * @tutorial https://uviewpro.cn/zh/components/color-select-panel.html
+ * @property {String} modelValue 绑定的颜色值（默认#000000）
+ * @property {'solid' | 'gradient' | 'both'} colorMode 颜色模式（默认both）
+ * @property {Boolean} showAlpha 是否显示透明度（默认true）
+ * @property {Boolean} showEyeDropper 是否显示吸管（默认true）
+ * @property {Boolean} showHistory 是否显示历史记录（默认true）
+ * @property {Boolean} showPresets 是否显示预设颜色（默认true）
+ * @property {Array} presets 预设颜色列表
+ * @property {'HEX' | 'RGB'} format 颜色格式（默认HEX）
+ * @property {Boolean} disabled 是否禁用
+ * @event update:modelValue 颜色值变化时触发
+ * @event change 颜色变化时触发
+ * @event color-update 颜色更新时触发
+ * @example <u-color-select-panel v-model="color" />
+ */
+const { t } = useLocale();
+const props = defineProps(ColorSelectPanelProps);
+const emit = defineEmits(['update:modelValue', 'change', 'color-update']);
+const instance = getCurrentInstance();
+
+// --- State ---
+const colorType = ref<'solid' | 'gradient'>('solid');
+const colorFormat = ref<'HEX' | 'RGB'>(props.format || 'HEX');
+const showFormatDropdown = ref(false);
+const tempColor = ref(props.modelValue || '#000000');
+const hsv = reactive({ h: 0, s: 0, v: 0, a: 1 });
+const rgb = reactive({ r: 0, g: 0, b: 0 });
+const isEyeDropperSupported = ref(false);
+const recentColors = ref<string[]>([]);
+const STORAGE_KEY = 'u-color-picker-recent';
+
+// Gradient State
+const gradientStops = ref<{ offset: number; color: string }[]>([
+    { offset: 0, color: '#ffffff' },
+    { offset: 1, color: '#000000' }
+]);
+const activeGradientIndex = ref(0);
+const gradientRect = ref({ left: 0, top: 0, width: 0, height: 0 });
+
+// Rect info
+const svRect = ref({ left: 0, top: 0, width: 0, height: 0 });
+const hueRect = ref({ left: 0, top: 0, width: 0, height: 0 });
+const alphaRect = ref({ left: 0, top: 0, width: 0, height: 0 });
+
+// --- Computed ---
+const gradientString = computed(() => {
+    const stops = [...gradientStops.value].sort((a, b) => a.offset - b.offset);
+    const stopsStr = stops.map(s => `${s.color} ${Math.round(s.offset * 100)}%`).join(', ');
+    return `linear-gradient(90deg, ${stopsStr})`;
+});
+
+const previewColor = computed(() => {
+    return colorType.value === 'solid' ? tempColor.value : gradientString.value;
+});
+
+const displayColorValue = ref('');
+const alphaInputValue = ref('100');
+
+// --- Logic ---
+
+// Hex to RGB
+function hexToRgb(hex: string) {
+    const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+    hex = hex.replace(shorthandRegex, (m, r, g, b) => r + r + g + g + b + b);
+    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})?$/i.exec(hex);
+    return result
+        ? {
+              r: Number.parseInt(result[1], 16),
+              g: Number.parseInt(result[2], 16),
+              b: Number.parseInt(result[3], 16),
+              a: result[4] ? Number.parseFloat((Number.parseInt(result[4], 16) / 255).toFixed(2)) : 1
+          }
+        : { r: 0, g: 0, b: 0, a: 1 };
+}
+
+// RGB to Hex
+function rgbToHex(r: number, g: number, b: number, a: number = 1) {
+    const hex = `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
+    if (a < 1) {
+        const alpha = Math.round(a * 255)
+            .toString(16)
+            .padStart(2, '0');
+        return hex + alpha;
+    }
+    return hex;
+}
+
+// RGB to HSV
+function rgbToHsv(r: number, g: number, b: number) {
+    r /= 255;
+    g /= 255;
+    b /= 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    let h = 0;
+    let s;
+    const v = max;
+    const d = max - min;
+    s = max === 0 ? 0 : d / max;
+    if (max === min) {
+        h = 0;
+    } else {
+        switch (max) {
+            case r:
+                h = (g - b) / d + (g < b ? 6 : 0);
+                break;
+            case g:
+                h = (b - r) / d + 2;
+                break;
+            case b:
+                h = (r - g) / d + 4;
+                break;
+        }
+        h /= 6;
+    }
+    return { h: h * 360, s, v };
+}
+
+// HSV to RGB
+function hsvToRgb(h: number, s: number, v: number) {
+    let r, g, b;
+    const i = Math.floor(h / 60);
+    const f = h / 60 - i;
+    const p = v * (1 - s);
+    const q = v * (1 - f * s);
+    const t = v * (1 - (1 - f) * s);
+    switch (i % 6) {
+        case 0:
+            r = v;
+            g = t;
+            b = p;
+            break;
+        case 1:
+            r = q;
+            g = v;
+            b = p;
+            break;
+        case 2:
+            r = p;
+            g = v;
+            b = t;
+            break;
+        case 3:
+            r = p;
+            g = q;
+            b = v;
+            break;
+        case 4:
+            r = t;
+            g = p;
+            b = v;
+            break;
+        case 5:
+            r = v;
+            g = p;
+            b = q;
+            break;
+        default:
+            r = g = b = 0;
+            break;
+    }
+    return {
+        r: Math.round(r * 255),
+        g: Math.round(g * 255),
+        b: Math.round(b * 255)
+    };
+}
+
+function updateDisplayValue() {
+    alphaInputValue.value = Math.round(hsv.a * 100).toString();
+    if (colorFormat.value === 'HEX') {
+        displayColorValue.value = tempColor.value.replace('#', '').toUpperCase();
+    } else {
+        displayColorValue.value = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${hsv.a})`;
+    }
+}
+
+function updateColorFromHsv() {
+    const { r, g, b } = hsvToRgb(hsv.h, hsv.s, hsv.v);
+    rgb.r = r;
+    rgb.g = g;
+    rgb.b = b;
+    const hex = rgbToHex(r, g, b, hsv.a);
+    tempColor.value = hex;
+
+    // Update Gradient Stop
+    if (colorType.value === 'gradient') {
+        gradientStops.value[activeGradientIndex.value].color = hex;
+        const finalColor = gradientString.value;
+        emit('change', finalColor);
+        emit('color-update', finalColor);
+        emit('update:modelValue', finalColor);
+    } else {
+        emit('change', hex);
+        emit('color-update', hex);
+        emit('update:modelValue', hex);
+    }
+    updateDisplayValue();
+}
+
+function initColor(val: string) {
+    if (!val) return;
+
+    // Check if gradient
+    if (val.includes('gradient')) {
+        colorType.value = 'gradient';
+        try {
+            const stopsMatch = val.match(/linear-gradient\([^,]+,\s*(.+)\)/);
+            if (stopsMatch && stopsMatch[1]) {
+                const stops = stopsMatch[1].split(',').map((s: string) => s.trim());
+                gradientStops.value = stops.map(s => {
+                    const parts = s.split(/\s+/);
+                    const color = parts[0];
+                    const offsetStr = parts[1] || '0%';
+                    const offset = Number.parseFloat(offsetStr) / 100;
+                    return { color, offset };
+                });
+                // Activate first stop
+                activeGradientIndex.value = 0;
+                parseSolidColor(gradientStops.value[0].color);
+            }
+        } catch (e) {
+            console.error('Gradient parse error', e);
+        }
+    } else {
+        // Only switch to solid if mode supports it
+        if (props.colorMode !== 'gradient') {
+            colorType.value = 'solid';
+        }
+        parseSolidColor(val);
+    }
+}
+
+function parseSolidColor(val: string) {
+    let hex = val;
+    let alpha = 1;
+    let r = 0;
+    let g = 0;
+    let b = 0;
+
+    if (val.startsWith('rgb')) {
+        const parts = val.match(/[\d.]+/g);
+        if (parts && parts.length >= 3) {
+            r = Number.parseInt(parts[0]);
+            g = Number.parseInt(parts[1]);
+            b = Number.parseInt(parts[2]);
+            if (parts.length >= 4) alpha = Number.parseFloat(parts[3]);
+            hex = rgbToHex(r, g, b, alpha);
+        }
+    } else {
+        const rgbVal = hexToRgb(val);
+        r = rgbVal.r;
+        g = rgbVal.g;
+        b = rgbVal.b;
+        alpha = rgbVal.a;
+    }
+
+    tempColor.value = hex;
+    rgb.r = r;
+    rgb.g = g;
+    rgb.b = b;
+    const hsvVal = rgbToHsv(r, g, b);
+    hsv.h = hsvVal.h;
+    hsv.s = hsvVal.s;
+    hsv.v = hsvVal.v;
+    hsv.a = alpha;
+
+    updateDisplayValue();
+}
+
+function selectFormat(fmt: 'HEX' | 'RGB') {
+    colorFormat.value = fmt;
+    showFormatDropdown.value = false;
+    updateDisplayValue();
+}
+
+function onColorInputBlur() {
+    let val = displayColorValue.value;
+    if (colorFormat.value === 'HEX') {
+        if (!val.startsWith('#')) val = `#${val}`;
+        if (/^#[0-9A-F]{6}$/i.test(val) || /^#[0-9A-F]{8}$/i.test(val)) {
+            parseSolidColor(val);
+            updateColorFromHsv();
+        }
+    } else {
+        parseSolidColor(val);
+        updateColorFromHsv();
+    }
+}
+
+function onAlphaInputBlur() {
+    let val = Number.parseFloat(alphaInputValue.value);
+    if (Number.isNaN(val)) val = 100;
+    val = Math.max(0, Math.min(100, val));
+    hsv.a = val / 100;
+    updateColorFromHsv();
+}
+
+function adjustAlpha(step: number) {
+    let val = Math.round(hsv.a * 100) + step;
+    val = Math.max(0, Math.min(100, val));
+    hsv.a = val / 100;
+    updateColorFromHsv();
+}
+
+// --- Gradient Logic ---
+
+function selectGradientStop(index: number) {
+    if (props.disabled) return;
+    activeGradientIndex.value = index;
+    parseSolidColor(gradientStops.value[index].color);
+}
+
+function onGradientTouchStart(e: TouchEvent) {
+    if (props.disabled) return;
+    getRects().then(() => {
+        // Check if we hit a stop
+        if (!gradientRect.value.width) return;
+        const touch = e.touches[0];
+        const x = touch.clientX - gradientRect.value.left;
+        const width = gradientRect.value.width;
+
+        // Find nearest stop
+        let minDist = Infinity;
+        let nearestIndex = -1;
+
+        gradientStops.value.forEach((stop, index) => {
+            const stopX = stop.offset * width;
+            const dist = Math.abs(x - stopX);
+            if (dist < minDist) {
+                minDist = dist;
+                nearestIndex = index;
+            }
+        });
+
+        // Threshold (e.g. 30px)
+        if (minDist < 30 && nearestIndex !== -1) {
+            activeGradientIndex.value = nearestIndex;
+            parseSolidColor(gradientStops.value[nearestIndex].color);
+        }
+
+        handleGradientTouch(e);
+    });
+}
+
+function onGradientTouchMove(e: TouchEvent) {
+    if (props.disabled) return;
+    handleGradientTouch(e);
+}
+
+function handleGradientTouch(e: TouchEvent) {
+    if (!gradientRect.value.width) return;
+    const touch = e.touches[0];
+    let x = touch.clientX - gradientRect.value.left;
+    x = Math.max(0, Math.min(x, gradientRect.value.width));
+    const offset = x / gradientRect.value.width;
+
+    gradientStops.value[activeGradientIndex.value].offset = Number.parseFloat(offset.toFixed(2));
+    updateColorFromHsv();
+}
+
+// --- Touch Handling ---
+
+function getRects() {
+    return new Promise<void>(resolve => {
+        const query = uni.createSelectorQuery().in(instance);
+        const svId = '#u-color-select-panel__sv-box';
+        const hueId = '#u-color-select-panel__hue-slider';
+        const alphaId = '#u-color-select-panel__alpha-slider';
+        const gradientId = '#u-color-select-panel__gradient-bar';
+
+        query
+            .select(svId)
+            .boundingClientRect(data => {
+                if (data) svRect.value = data as any;
+            })
+            .select(hueId)
+            .boundingClientRect(data => {
+                if (data) hueRect.value = data as any;
+            })
+            .select(alphaId)
+            .boundingClientRect(data => {
+                if (data) alphaRect.value = data as any;
+            })
+            .select(gradientId)
+            .boundingClientRect(data => {
+                if (data) gradientRect.value = data as any;
+                resolve();
+            })
+            .exec();
+    });
+}
+
+function onSvTouchStart(e: TouchEvent) {
+    if (props.disabled) return;
+    getRects().then(() => {
+        handleSvTouch(e);
+    });
+}
+
+function onSvTouchMove(e: TouchEvent) {
+    if (props.disabled) return;
+    handleSvTouch(e);
+}
+
+function handleSvTouch(e: TouchEvent) {
+    if (!svRect.value.width) return;
+    const touch = e.touches[0];
+    let x = touch.clientX - svRect.value.left;
+    let y = touch.clientY - svRect.value.top;
+
+    x = Math.max(0, Math.min(x, svRect.value.width));
+    y = Math.max(0, Math.min(y, svRect.value.height));
+
+    hsv.s = x / svRect.value.width;
+    hsv.v = 1 - y / svRect.value.height;
+
+    updateColorFromHsv();
+}
+
+function onHueTouchStart(e: TouchEvent) {
+    if (props.disabled) return;
+    getRects().then(() => {
+        handleHueTouch(e);
+    });
+}
+
+function onHueTouchMove(e: TouchEvent) {
+    if (props.disabled) return;
+    handleHueTouch(e);
+}
+
+function handleHueTouch(e: TouchEvent) {
+    if (!hueRect.value.width) return;
+    const touch = e.touches[0];
+    let x = touch.clientX - hueRect.value.left;
+    x = Math.max(0, Math.min(x, hueRect.value.width));
+    hsv.h = (x / hueRect.value.width) * 360;
+    updateColorFromHsv();
+}
+
+function onAlphaTouchStart(e: TouchEvent) {
+    if (props.disabled) return;
+    getRects().then(() => {
+        handleAlphaTouch(e);
+    });
+}
+
+function onAlphaTouchMove(e: TouchEvent) {
+    if (props.disabled) return;
+    handleAlphaTouch(e);
+}
+
+function handleAlphaTouch(e: TouchEvent) {
+    if (!alphaRect.value.width) return;
+    const touch = e.touches[0];
+    let x = touch.clientX - alphaRect.value.left;
+    x = Math.max(0, Math.min(x, alphaRect.value.width));
+    hsv.a = Number.parseFloat((x / alphaRect.value.width).toFixed(2));
+    updateColorFromHsv();
+}
+
+// --- EyeDropper ---
+async function openEyeDropper() {
+    if (props.disabled) return;
+    // #ifdef H5
+    if (!isEyeDropperSupported.value) return;
+    const eyeDropper = new (window as any).EyeDropper();
+    try {
+        const result = await eyeDropper.open();
+        const hex = result.sRGBHex;
+        parseSolidColor(hex);
+        updateColorFromHsv();
+    } catch (e) {
+        console.log('User canceled selection');
+    }
+    // #endif
+}
+
+// --- Presets ---
+function selectSwatch(color: string) {
+    if (props.disabled) return;
+    if (color.includes('gradient')) {
+        colorType.value = 'gradient';
+        initColor(color);
+        emit('change', color);
+        emit('update:modelValue', color);
+    } else {
+        colorType.value = 'solid';
+        parseSolidColor(color);
+        updateColorFromHsv();
+    }
+}
+
+function loadRecentColors() {
+    try {
+        const stored = uni.getStorageSync(STORAGE_KEY);
+        if (stored) {
+            recentColors.value = JSON.parse(stored);
+        }
+    } catch (e) {
+        console.error('Failed to load recent colors', e);
+    }
+}
+
+// --- API ---
+function setColor(color: string) {
+    initColor(color);
+}
+
+function getColor(): ColorObject {
+    return {
+        hex: tempColor.value,
+        rgb: { ...rgb },
+        hsl: { h: hsv.h, s: hsv.s, l: hsv.v }, // Approximation
+        hsv: { ...hsv },
+        alpha: hsv.a,
+        source: colorFormat.value.toLowerCase()
+    };
+}
+
+function saveRecentColor(color: string) {
+    if (!color) return;
+    const index = recentColors.value.indexOf(color);
+    if (index > -1) {
+        recentColors.value.splice(index, 1);
+    }
+    recentColors.value.unshift(color);
+    if (recentColors.value.length > 10) {
+        recentColors.value.pop();
+    }
+    uni.setStorageSync(STORAGE_KEY, JSON.stringify(recentColors.value));
+    recentColors.value = [...recentColors.value];
+}
+
+defineExpose({
+    setColor,
+    getColor,
+    saveRecentColor
+});
+
+// --- Watchers & Lifecycle ---
+watch(
+    () => props.format,
+    val => {
+        if (val) colorFormat.value = val;
+    }
+);
+
+watch(
+    () => props.modelValue,
+    val => {
+        if (colorType.value === 'solid') {
+            if (val !== tempColor.value) initColor(val);
+        } else {
+            if (val !== gradientString.value) initColor(val);
+        }
+    }
+);
+
+watch(
+    () => props.colorMode,
+    val => {
+        if (val === 'solid') colorType.value = 'solid';
+        if (val === 'gradient') colorType.value = 'gradient';
+    }
+);
+
+watch(
+    () => props.showAlpha,
+    val => {
+        if (val) {
+            initColor(props.modelValue);
+            nextTick(() => {
+                setTimeout(() => getRects(), 200);
+            });
+        }
+    }
+);
+
+onMounted(() => {
+    if (props.colorMode === 'gradient') colorType.value = 'gradient';
+    initColor(props.modelValue);
+    loadRecentColors();
+    nextTick(() => {
+        getRects();
+    });
+    // #ifdef H5
+    if (typeof window !== 'undefined' && 'EyeDropper' in window) {
+        isEyeDropperSupported.value = true;
+    }
+    // #endif
+});
+</script>
+
+<style lang="scss" scoped>
+@import 'uview-pro/libs/css/style.components.scss';
+
+.u-color-select-panel {
+    background-color: var(--u-bg-color);
+    color: var(--u-main-color);
+    padding: 24rpx;
+    transition:
+        background-color 0.3s,
+        color 0.3s;
+
+    &__tabs {
+        @include vue-flex;
+        background-color: var(--u-light-color);
+        padding: 6rpx;
+        border-radius: 8rpx;
+        margin-bottom: 24rpx;
+    }
+
+    &__tab-item {
+        flex: 1;
+        text-align: center;
+        font-size: 24rpx;
+        color: var(--u-main-color);
+        padding: 10rpx 0;
+        border-radius: 6rpx;
+        transition: all 0.2s;
+
+        &--active {
+            background-color: var(--u-bg-white);
+            color: var(--u-main-color);
+            box-shadow: 0 2rpx 6rpx rgba(0, 0, 0, 0.05);
+            font-weight: 500;
+        }
+    }
+
+    // Gradient Bar
+    &__gradient-bar-wrapper {
+        position: relative;
+        width: 100%;
+        height: 40rpx;
+        margin-bottom: 24rpx;
+    }
+
+    &__gradient-bg {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        border-radius: 20rpx;
+        background-image:
+            linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%),
+            linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%);
+        background-size: 16rpx 16rpx;
+        background-color: #fff;
+    }
+
+    &__gradient-bar {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        border-radius: 20rpx;
+        box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+    }
+
+    &__gradient-stop {
+        position: absolute;
+        top: 50%;
+        width: 32rpx;
+        height: 32rpx;
+        border-radius: 50%;
+        background-color: #fff;
+        border: 4rpx solid #fff;
+        box-shadow: 0 2rpx 6rpx rgba(0, 0, 0, 0.3);
+        transform: translate(-50%, -50%);
+        box-sizing: border-box;
+        z-index: 10;
+
+        &--active {
+            transform: translate(-50%, -50%) scale(1.2);
+            border-color: var(--u-main-color);
+            z-index: 20;
+        }
+    }
+
+    // SV Box
+    &__sv-box {
+        position: relative;
+        width: 100%;
+        height: 320rpx;
+        border-radius: 12rpx;
+        overflow: hidden;
+        margin-bottom: 24rpx;
+        box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+    }
+
+    &__sv-white {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
+    }
+
+    &__sv-black {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: linear-gradient(to top, #000, rgba(0, 0, 0, 0));
+    }
+
+    &__sv-cursor {
+        position: absolute;
+        width: 24rpx;
+        height: 24rpx;
+        border-radius: 50%;
+        border: 2px solid #fff;
+        box-shadow: 0 0 4rpx rgba(0, 0, 0, 0.5);
+        transform: translate(-50%, -50%);
+        box-sizing: border-box;
+    }
+
+    // Middle Row
+    &__middle-row {
+        @include vue-flex;
+        gap: 20rpx;
+        margin-bottom: 24rpx;
+        height: 80rpx;
+    }
+
+    &__sliders-col {
+        flex: 1;
+        @include vue-flex;
+        flex-direction: column;
+        justify-content: space-between;
+    }
+
+    &__slider-wrapper {
+        position: relative;
+        width: 100%;
+        height: 32rpx;
+        border-radius: 16rpx;
+    }
+
+    &__hue-bar {
+        width: 100%;
+        height: 100%;
+        border-radius: 16rpx;
+        background: linear-gradient(to right, #f00 0%, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%);
+        position: relative;
+    }
+
+    &__alpha-bg {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        border-radius: 16rpx;
+        background-image:
+            linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%),
+            linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%);
+        background-size: 16rpx 16rpx;
+        background-color: #fff;
+    }
+
+    &__alpha-bar {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        border-radius: 16rpx;
+    }
+
+    &__slider-thumb {
+        position: absolute;
+        top: 50%;
+        width: 40rpx;
+        height: 40rpx;
+        border-radius: 50%;
+        background-color: #fff;
+        box-shadow: 0 2rpx 6rpx rgba(0, 0, 0, 0.2);
+        transform: translate(-50%, -50%);
+        border: 4rpx solid #fff;
+        box-sizing: border-box;
+
+        &::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 100%;
+            height: 100%;
+            border-radius: 50%;
+            border: 1px solid rgba(0, 0, 0, 0.1);
+            transform: translate(-50%, -50%);
+        }
+    }
+
+    &__preview-block {
+        width: 80rpx;
+        height: 80rpx;
+        margin-left: 5rpx;
+        border-radius: 12rpx;
+        box-shadow: 0 2rpx 8rpx rgba(0, 0, 0, 0.05);
+    }
+
+    // Input Row
+    &__input-row {
+        @include vue-flex;
+        align-items: center;
+        gap: 16rpx;
+        margin-bottom: 30rpx;
+    }
+
+    &__format-selector {
+        position: relative;
+        min-width: 80rpx;
+    }
+
+    &__format-current {
+        @include vue-flex;
+        align-items: center;
+        font-size: 26rpx;
+        color: var(--u-main-color);
+        padding: 10rpx 0;
+    }
+
+    &__format-dropdown {
+        position: absolute;
+        bottom: 100%;
+        left: 0;
+        background-color: var(--u-bg-color);
+        border-radius: 8rpx;
+        box-shadow: 0 4rpx 16rpx rgba(0, 0, 0, 0.1);
+        padding: 8rpx 0;
+        z-index: 100;
+        width: 120rpx;
+        border: 1px solid var(--u-border-color);
+    }
+
+    &__format-option {
+        padding: 12rpx 20rpx;
+        font-size: 26rpx;
+        color: var(--u-main-color);
+
+        &--active {
+            color: var(--u-primary-color, #3c9cff);
+            background-color: var(--u-bg-white);
+        }
+    }
+
+    &__input-container {
+        flex: 1;
+        height: 64rpx;
+        background-color: var(--u-bg-white);
+        border-radius: 8rpx;
+        @include vue-flex;
+        align-items: center;
+        padding: 0 16rpx;
+        border: 1px solid transparent;
+        transition: all 0.2s;
+
+        &:focus-within {
+            background-color: var(--u-bg-white);
+            border-color: var(--u-primary-color, #3c9cff);
+        }
+    }
+
+    &__input-prefix {
+        color: var(--u-main-color);
+        font-size: 26rpx;
+        margin-right: 8rpx;
+    }
+
+    &__hex-input {
+        flex: 1;
+        color: var(--u-main-color);
+        font-size: 26rpx;
+        font-family: monospace;
+    }
+
+    &__alpha-control {
+        @include vue-flex;
+        align-items: center;
+        background-color: var(--u-bg-white);
+        border-radius: 8rpx;
+        height: 64rpx;
+        padding: 0 4rpx;
+    }
+
+    &__alpha-btn {
+        width: 40rpx;
+        height: 100%;
+        @include vue-flex;
+        align-items: center;
+        justify-content: center;
+
+        &:active {
+            opacity: 0.7;
+        }
+    }
+
+    &__alpha-input-wrapper {
+        position: relative;
+        width: 70rpx;
+        height: 100%;
+        @include vue-flex;
+        align-items: center;
+    }
+
+    &__alpha-input {
+        flex: 1;
+        color: var(--u-main-color);
+        font-size: 26rpx;
+        text-align: center;
+    }
+
+    &__alpha-percent {
+        position: absolute;
+        right: 0;
+        color: var(--u-main-color);
+        font-size: 20rpx;
+        pointer-events: none;
+    }
+
+    &__eyedropper-btn {
+        width: 64rpx;
+        height: 64rpx;
+        background-color: var(--u-bg-white);
+        border-radius: 8rpx;
+        @include vue-flex;
+        align-items: center;
+        justify-content: center;
+
+        &:active {
+            background-color: var(--u-border-color);
+        }
+    }
+
+    // Presets
+    &__presets {
+        margin-bottom: 30rpx;
+    }
+
+    &__section-title {
+        font-size: 24rpx;
+        color: var(--u-main-color);
+        margin-bottom: 16rpx;
+        display: block;
+    }
+
+    &__swatches-grid {
+        @include vue-flex;
+        flex-wrap: wrap;
+        gap: 16rpx;
+    }
+
+    &__swatch {
+        width: 48rpx;
+        height: 48rpx;
+        border-radius: 8rpx;
+        box-sizing: border-box;
+        transition: transform 0.1s;
+
+        &:active {
+            transform: scale(0.9);
+        }
+    }
+}
+</style>

--- a/src/uni_modules/uview-pro/locale/lang/en-US.ts
+++ b/src/uni_modules/uview-pro/locale/lang/en-US.ts
@@ -107,6 +107,17 @@ export default {
         holiday: '休',
         workday: '班'
     },
+    uColorPicker: {
+        title: 'Select Color',
+        confirmText: 'Confirm',
+        cancelText: 'Cancel'
+    },
+    uColorSelectPanel: {
+        solid: 'Solid',
+        gradient: 'Gradient',
+        recentColors: 'Recent Colors',
+        systemPresets: 'System Presets'
+    },
     uEmpty: {
         car: 'Shopping cart is empty',
         page: 'Page not found',

--- a/src/uni_modules/uview-pro/locale/lang/zh-CN.ts
+++ b/src/uni_modules/uview-pro/locale/lang/zh-CN.ts
@@ -107,6 +107,17 @@ export default {
         holiday: '休',
         workday: '班'
     },
+    uColorPicker: {
+        title: '选择颜色',
+        confirmText: '确定',
+        cancelText: '取消'
+    },
+    uColorSelectPanel: {
+        solid: '单色',
+        gradient: '渐变色',
+        recentColors: '最近使用颜色',
+        systemPresets: '系统预设颜色'
+    },
     uEmpty: {
         car: '购物车为空',
         page: '页面不存在',


### PR DESCRIPTION
# ColorPicker 颜色选择器

该组件用于颜色选择，包含弹窗模式（`u-color-picker`）和内联面板模式（`u-color-select-panel`）两个组件，支持单色、渐变色、透明度调节、历史记录、预设颜色、吸管取色等功能，可根据场景灵活使用。

## 平台差异说明

| App | H5 | 微信小程序 | 支付宝小程序 | 百度小程序 | 头条小程序 | QQ小程序 |
| :--: | :--: | :--: | :--: | :--: | :--: | :--: |
| √ | √ | √ | √ | √ | √ | √ |

> 注意：吸管取色（EyeDropper）功能仅在支持 `EyeDropper API` 的浏览器环境（如 Chrome Desktop）中可用，小程序和移动端 H5 环境暂不支持。

## 基本使用

### 弹窗模式

使用 `u-color-picker` 组件，通过 `v-model:show` 控制弹窗显隐，`v-model` 双向绑定颜色值。

```html
<template>
    <view>
        <u-button @click="showPicker = true">打开颜色选择器</u-button>
        <view :style="{ background: color, width: '100px', height: '100px' }"></view>

        <u-color-picker
            :show="showPicker"
            v-model="color"
            @confirm="onConfirm"
            @cancel="showPicker = false"
        ></u-color-picker>
    </view>
</template>

<script setup>
import { ref } from 'vue';

const showPicker = ref(false);
const color = ref('#2979ff');

const onConfirm = (e) => {
    console.log('选择的颜色：', e);
    showPicker.value = false;
};
</script>
```

### 内联模式

使用 `u-color-select-panel` 组件直接嵌入页面，无需弹窗。

```html
<template>
    <view class="page">
        <u-color-select-panel
            v-model="color"
            @change="onChange"
        ></u-color-select-panel>
    </view>
</template>

<script setup>
import { ref } from 'vue';

const color = ref('#2979ff');

const onChange = (e) => {
    console.log('实时颜色变化：', e);
};
</script>
```

### 自定义样式

通过 `customStyle` 和 `customClass` 可自定义组件根节点的样式。

```html
<template>
    <u-color-picker
        v-model="color"
        :show="show"
        :customStyle="{ borderRadius: '24rpx' }"
        customClass="my-custom-picker"
    ></u-color-picker>
</template>
```

## API

### u-color-picker Props

| 参数 | 说明 | 类型 | 默认值 | 可选值 |
| :-- | :-- | :-- | :-- | :-- |
| v-model | 绑定的颜色值 | String | `#000000` | - |
| show | 是否显示弹窗 | Boolean | `false` | - |
| mode | 显示模式 | String | `popup` | `popup`, `inline` |
| title | 弹窗标题 | String | `选择颜色` | - |
| confirmText | 确认按钮文字 | String | `确定` | - |
| cancelText | 取消按钮文字 | String | `取消` | - |
| shape | 触发器形状 | String | `square` | `square`, `circle` |
| size | 触发器大小 | String \| Number | `60rpx` | - |
| zIndex | 弹窗层级 | String \| Number | `10075` | - |
| colorMode | 颜色模式 | String | `both` | `solid`, `gradient`, `both` |
| showAlpha | 是否显示透明度调节 | Boolean | `true` | `true`, `false` |
| showEyeDropper | 是否显示吸管工具 | Boolean | `true` | `true`, `false` |
| showHistory | 是否显示最近使用颜色 | Boolean | `true` | `true`, `false` |
| showPresets | 是否显示预设颜色 | Boolean | `true` | `true`, `false` |
| presets | 预设颜色列表 | Array | `[...]` | - |
| format | 颜色格式 | String | `HEX` | `HEX`, `RGB` |
| disabled | 是否禁用 | Boolean | `false` | - |
| customStyle | 自定义根节点样式 | Object \| String | `{}` | - |
| customClass | 自定义根节点样式类 | String | `''` | - |

### u-color-picker Events

| 事件名 | 说明 | 回调参数 |
| :-- | :-- | :-- |
| confirm | 点击确定按钮触发 | `color: string` |
| cancel | 点击取消或关闭弹窗触发 | - |
| change | 颜色改变时实时触发 | `color: string` |
| color-update | 颜色每次更新时触发 | `color: string` |
| update:modelValue | 颜色值变化时触发（v-model） | `color: string` |
| update:show | 弹窗显隐状态变化时触发 | `show: boolean` |

### u-color-select-panel Props

| 参数 | 说明 | 类型 | 默认值 | 可选值 |
| :-- | :-- | :-- | :-- | :-- |
| v-model | 绑定的颜色值 | String | `#000000` | - |
| colorMode | 颜色模式 | String | `both` | `solid`, `gradient`, `both` |
| showAlpha | 是否显示透明度调节 | Boolean | `true` | `true`, `false` |
| showEyeDropper | 是否显示吸管工具 | Boolean | `true` | `true`, `false` |
| showHistory | 是否显示最近使用颜色 | Boolean | `true` | `true`, `false` |
| showPresets | 是否显示预设颜色 | Boolean | `true` | `true`, `false` |
| presets | 预设颜色列表 | Array | `[...]` | - |
| format | 颜色格式 | String | `HEX` | `HEX`, `RGB` |
| disabled | 是否禁用 | Boolean | `false` | - |
| customStyle | 自定义根节点样式 | Object \| String | `{}` | - |
| customClass | 自定义根节点样式类 | String | `''` | - |

### u-color-select-panel Events

| 事件名 | 说明 | 回调参数 |
| :-- | :-- | :-- |
| change | 颜色改变时实时触发 | `color: string` |
| color-update | 颜色每次更新时触发 | `color: string` |
| update:modelValue | 颜色值变化时触发（v-model） | `color: string` |

### u-color-select-panel Methods

可通过 `ref` 调用组件内部方法。

| 方法名 | 说明 | 参数 | 返回值 |
| :-- | :-- | :-- | :-- |
| setColor | 主动设置颜色 | `color: string` | - |
| getColor | 获取当前颜色对象详细信息 | - | `ColorObject` |
| saveRecentColor | 保存指定颜色到历史记录 | `color: string` | - |

#### ColorObject 类型定义

```typescript
interface ColorObject {
    hex: string;          // 十六进制颜色值，如 #ff0000ff
    rgb: {                // RGB 对象
        r: number;
        g: number;
        b: number;
    };
    hsl: {                // HSL 对象
        h: number;
        s: number;
        l: number;
    };
    hsv: {                // HSV 对象
        h: number;
        s: number;
        v: number;
    };
    alpha: number;        // 透明度 0-1
    source: string;       // 来源格式 'hex' | 'rgb' | 'hsl'
}
```

## 功能特性详解

### 1. 渐变色支持

当 `colorMode` 设置为 `gradient` 或 `both` 时，组件支持 CSS 线性渐变（linear-gradient）。

- 面板顶部会出现渐变控制条，可添加/选择颜色断点（Stop）
- 点击断点可选中，选中的断点会放大高亮显示
- 拖动断点可调整其在渐变中的位置
- 选中断点后，下方选色区域将控制该断点的颜色
- v-model 的值在渐变模式下为 `linear-gradient(90deg, #fff 0%, #000 100%)` 格式

### 2. 颜色格式切换

点击输入框左侧的格式标签可以切换颜色显示格式。

- HEX：支持 6 位（`#RRGGBB`）和 8 位（`#RRGGBBAA`）格式
- RGB：显示为 `rgba(r, g, b, a)` 格式

### 3. 吸管工具 (EyeDropper)

在支持 `EyeDropper API` 的 H5 环境（桌面端 Chrome/Edge），点击吸管图标可以吸取屏幕上任意位置的颜色。移动端 H5 或小程序环境暂不支持此 API，吸管按钮会自动隐藏。

### 4. 历史记录

组件会自动保存最近使用的 10 个颜色到本地存储，方便快速复用。可通过 `showHistory` 控制是否显示历史记录区域，通过 `saveRecentColor` 方法手动保存颜色。

### 5. 预设颜色

支持通过 `presets` 属性自定义预设颜色列表，组件内置了 15 种常用颜色作为默认值。可通过 `showPresets` 控制是否显示预设颜色区域。

### 6. 暗黑模式适配

组件内置了对暗黑模式的支持，会自动感知当前应用的主题设置并切换相应的背景色和文字颜色。无需额外配置。
