### PR TITLE
fix(types): 修复 uview-pro/types 无法解析的问题

### DIFF
--- a/src/uni_modules/uview-pro/package.json
+++ b/src/uni_modules/uview-pro/package.json
@@ -9,6 +9,7 @@
     "browser": "index.ts",
     "exports": {
         ".": "./index.ts",
+        "./types": "./types/index.d.ts",
         "./plugins": {
             "types": "./plugins/index.ts",
             "import": "./plugins/index.mjs",


### PR DESCRIPTION
修复如下类型问题。

<img width="786" height="331" alt="image" src="https://github.com/user-attachments/assets/5c57cdaa-7be7-4b96-8963-5eb332bb9570" />
